### PR TITLE
Fix: [MacOS] manual sign libraries, as otherwise we miscalculate their checksums

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -135,6 +135,7 @@ jobs:
         echo "::endgroup::"
       env:
         OPENTTD_PLUGIN_PRIVATE_KEY: ${{ secrets.OPENTTD_PLUGIN_PRIVATE_KEY }}
+        APPLE_DEVELOPER_CERTIFICATE_ID: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_ID }}
 
     - name: Notarize
       env:

--- a/cmake/PackageBundle.cmake
+++ b/cmake/PackageBundle.cmake
@@ -6,10 +6,6 @@ set(CPACK_BUNDLE_PLIST "${CMAKE_CURRENT_BINARY_DIR}/Info.plist")
 set(CPACK_DMG_BACKGROUND_IMAGE "${CMAKE_SOURCE_DIR}/os/macos/splash.png")
 set(CPACK_DMG_FORMAT "UDBZ")
 set(CPACK_DMG_DISABLE_APPLICATIONS_SYMLINK ON)
-# This seems to be a bit buggy, as CPACK_APPLE_BUNDLE_ID is only referenced once in the source:
-# https://github.com/Kitware/CMake/blob/a3f76a4e4dc15997f22306b002fbc452af1259a6/Source/CPack/cmCPackBundleGenerator.cxx#L206C35-L206C56
-# But if we don't set it, the codesign step will be invalid. So yeah .. weird.
-set(CPACK_APPLE_BUNDLE_ID "org.openttd.${PROJECT_NAME}")
 
 # Create a temporary Info.plist.in, where we will fill in the version via
 # CPackProperties.cmake.in. This because at this point in time the version
@@ -17,9 +13,6 @@ set(CPACK_APPLE_BUNDLE_ID "org.openttd.${PROJECT_NAME}")
 configure_file("${CMAKE_SOURCE_DIR}/os/macos/Info.plist.in" "${CMAKE_CURRENT_BINARY_DIR}/Info.plist.in")
 set(CPACK_BUNDLE_PLIST_SOURCE "${CMAKE_CURRENT_BINARY_DIR}/Info.plist.in")
 
-get_target_property(LIBRARIES ${PROJECT_NAME} LINK_LIBRARIES)
-string(REGEX REPLACE "([^;]+)" "/Contents/Resources/\\1.dylib" LIBRARIES "${LIBRARIES}")
-set(CPACK_BUNDLE_APPLE_CODESIGN_FILES "/Contents/Resources/lib${PROJECT_NAME}.dylib;${LIBRARIES}")
 set(CPACK_BUNDLE_APPLE_CODESIGN_PARAMETER "--deep -f --options runtime")
 
 # Copy "Install" script to the bundle root.

--- a/cmake/PostInstall.cmake.in
+++ b/cmake/PostInstall.cmake.in
@@ -20,6 +20,15 @@ message(STATUS "Creating signature file ${MAIN_LIBRARY_NAME}.sig for the followi
 foreach(LIBRARY ${LIBRARIES})
     get_filename_component(LIBRARY_NAME "${LIBRARY}" NAME)
     message(STATUS "- ${LIBRARY_NAME}")
+
+    # Sign the libraries just before we calculate the checksum.
+    # This way CPack did all its magic, and if we let CPack do the signing
+    # we calculate the wrong checksum (as it happens after this step).
+    if (APPLE)
+        execute_process(
+            COMMAND codesign --deep -f --options runtime -s "$ENV{APPLE_DEVELOPER_CERTIFICATE_ID}" -i org.openttd.${CPACK_PACKAGE_NAME} ${LIBRARY}
+        )
+    endif()
 endforeach()
 
 execute_process(


### PR DESCRIPTION
Signing in CMake is done after the post-install hook, and there is no hook-entry between signing creating the DMG. In result, we have no way of calculating the checksums based on the signed libraries.

To resolve this, manually sign just before we calculate the checksum of the files, which is just before CPack signs the DMG (but not the libraries).